### PR TITLE
[codex] support project-level constexpr generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,18 +263,18 @@ xrobot_init_mod --config my_config.yaml --directory MyModules
 
 ### `xrobot_gen_main`
 
-该工具用于根据模块清单和构造参数配置文件，自动生成 C++ 入口函数 `XRobotMain()`，支持嵌套参数、重复实例、多模块构造。
-This tool generates a C++ entry function `XRobotMain()` based on the module list and configuration file, supporting nested args, multiple instances, and module composition.
+该工具用于根据模块实例配置生成 `XRobotMain()`，并在需要时同步生成项目级 `constexpr` 头文件。配置文件默认是 `User/xrobot.yaml`。
+This tool generates `XRobotMain()` from the module instance configuration, and can also emit a project-level `constexpr` header when requested. The default config file is `User/xrobot.yaml`.
 
 #### 🚀 使用方法 / Usage
 
 ```bash
-# 自动发现所有模块并生成主函数
-# Auto-discover modules and generate main entry
-xrobot_gen_main --output User/xrobot_main.hpp
+# 使用 User/xrobot.yaml 中的 modules 列表生成主函数
+# Generate main entry from module instances declared in User/xrobot.yaml
+xrobot_gen_main --output User/xrobot_main.hpp --config User/xrobot.yaml
 
-# 指定模块和构造参数配置
-# Specify modules and config manually
+# 直接指定模块名列表；若配置文件不存在则按模块 manifest 生成默认配置
+# Specify module names manually; if config is missing, generate a default one from module manifests
 xrobot_gen_main -o main.cpp -m BlinkLED Motor IMU --config User/xrobot.yaml
 ```
 
@@ -285,29 +285,73 @@ xrobot_gen_main -o main.cpp -m BlinkLED Motor IMU --config User/xrobot.yaml
   Output path of generated C++ file, default is `User/xrobot_main.hpp`.
 
 - `--modules`, `-m`
-  可选，指定模块名列表；若未指定，则自动扫描 `Modules/` 目录下的模块。
-  Optional. List of module names to include. If omitted, auto-discovered from `Modules/`.
+  可选，指定模块名列表。若未指定，则优先读取配置文件中 `modules[].name`；若仍为空，再回退到自动扫描 `Modules/`。
+  Optional. List of module names to include. If omitted, the generator first reads `modules[].name` from the config, and falls back to auto-discovery under `Modules/` only when needed.
 
 - `--hw`
   可选，指定硬件容器变量名，默认为 `hw`。
   Optional. Hardware container variable name. Default: `hw`.
 
 - `--config`, `-c`
-  可选，指定构造参数 YAML 文件；若文件不存在，则自动生成。
-  Optional. Path to constructor configuration file. Will be created if not found.
+  可选，指定实例配置 YAML 文件。若文件不存在，将根据模块 manifest 自动生成默认配置。
+  Optional. Path to the instance configuration YAML. If the file does not exist, a default config will be generated from module manifests.
+
+#### 🧩 `User/xrobot.yaml` 配置结构 / Configuration Layout
+
+```yaml
+global_settings:
+  monitor_sleep_ms: 5
+
+constexpr_includes:
+  - libxr_def.hpp
+
+constexprs:
+  MainCameraInfo:
+    type: CameraBase::StaticInfo
+    value:
+      width: 1280
+      height: 1024
+      fps: 100
+  DebugEnable:
+    type: bool
+    value: true
+
+modules:
+  - id: cam
+    name: WebotsCamera
+    template_args:
+      Info: {constexpr: MainCameraInfo}
+    constructor_args:
+      info: {constexpr: MainCameraInfo}
+
+  - id: detector
+    name: ArmorDetector
+    constructor_args:
+      camera: @cam
+      debug: {constexpr: DebugEnable}
+```
+
+- `global_settings.monitor_sleep_ms` 控制主循环中的 `Thread::Sleep(...)`。
+  `global_settings.monitor_sleep_ms` controls the `Thread::Sleep(...)` call in the generated main loop.
+- `modules` 是模块实例列表；`id` 用作生成出来的 C++ 实例名，`name` 是模块类名。
+  `modules` is the module instance list; `id` becomes the generated C++ instance name, and `name` is the module class name.
+- `constructor_args` 与 `template_args` 会按配置顺序展开到构造参数和模板参数中。
+  `constructor_args` and `template_args` are expanded into constructor arguments and template arguments in config order.
+- `{constexpr: Name}` 会展开为 `XRobotProject::Name`；若顶层存在 `constexprs`，则会额外生成 `xrobot_constexpr.hpp`。
+  `{constexpr: Name}` expands to `XRobotProject::Name`; when top-level `constexprs` exists, `xrobot_constexpr.hpp` is generated alongside the main file.
+- `@instance_id` 会被当作已有 C++ 实例名直接引用，例如 `@cam` 会展开为 `cam`。
+  `@instance_id` is emitted as a direct C++ instance reference, for example `@cam` expands to `cam`.
 
 #### 📤 输出结果 / Output
 
-- 若未指定 `--config`，将扫描模块头文件中的 `/* === MODULE MANIFEST === */` 区块并生成默认 YAML
-  If `--config` is not specified, will scan for `/* === MODULE MANIFEST === */` block and generate default YAML.
-- 生成一个包含 `XRobotMain()` 函数的 `.hpp` 或 `.cpp` 文件
-  Generates a `.hpp` or `.cpp` file containing the `XRobotMain()` function.
-- 每个模块按 `static ModuleName<HardwareContainer> name(hw, appmgr, ...);` 格式实例化
-  Each module is instantiated as `static ModuleName<HardwareContainer> name(hw, appmgr, ...);`
-- 支持自动添加头文件
-  Support for automatically adding header files
-- 主循环使用 `appmgr.MonitorAll()` 与 `Thread::Sleep()`
-  Main loop uses `appmgr.MonitorAll()` and `Thread::Sleep()`
+- 生成一个包含 `XRobotMain()` 的 `.hpp` 或 `.cpp` 文件。
+  Generates a `.hpp` or `.cpp` file containing `XRobotMain()`.
+- 当配置里存在 `constexprs` 时，会在输出文件同目录额外生成 `xrobot_constexpr.hpp`。
+  When `constexprs` exists in the config, an extra `xrobot_constexpr.hpp` file is generated next to the main output.
+- 每个模块按 `static ModuleName<...> id(hw, appmgr, ...);` 形式实例化。
+  Each module instance is emitted in the form `static ModuleName<...> id(hw, appmgr, ...);`.
+- 主循环使用 `appmgr.MonitorAll()` 与 `Thread::Sleep(monitor_sleep_ms)`。
+  The main loop uses `appmgr.MonitorAll()` and `Thread::Sleep(monitor_sleep_ms)`.
 
 输出代码示例 / Output Code Example：
 
@@ -316,23 +360,21 @@ xrobot_gen_main -o main.cpp -m BlinkLED Motor IMU --config User/xrobot.yaml
 #include "libxr.hpp"
 
 // Module headers
-#include "BlinkLED.hpp"
-#include "BMI088.hpp"
-#include "MadgwickAHRS.hpp"
+#include "WebotsCamera.hpp"
+#include "ArmorDetector.hpp"
+#include "xrobot_constexpr.hpp"
 
-template <typename HardwareContainer>
-static void XRobotMain(HardwareContainer &hw) {
+static void XRobotMain(LibXR::HardwareContainer &hw) {
   using namespace LibXR;
   ApplicationManager appmgr;
 
   // Auto-generated module instantiations
-  static BlinkLED<HardwareContainer> blinkled(hw, appmgr, 250);
-  static BMI088<HardwareContainer> bmi088(hw, appmgr, {1.0, 0.0, 0.0, 0.0}, {0.15, 1.0, 0.1, 0.0, 0.3, 1.0, false}, "bmi088_gyro", "bmi088_accl", 45, 512);
-  static MadgwickAHRS<HardwareContainer> madgwickahrs(hw, appmgr, 0.033, "bmi088_gyro", "bmi088_accl", "ahrs_quaternion", "ahrs_euler", 512);
+  static WebotsCamera<XRobotProject::MainCameraInfo> cam(hw, appmgr, XRobotProject::MainCameraInfo);
+  static ArmorDetector detector(hw, appmgr, cam, XRobotProject::DebugEnable);
 
   while (true) {
     appmgr.MonitorAll();
-    Thread::Sleep(1000);
+    Thread::Sleep(5);
   }
 }
 ```
@@ -462,8 +504,8 @@ Required Hardware : led/LED/led1/LED1
 
 ### `xrobot_setup`
 
-该工具用于自动配置 XRobot 环境，生成模块仓库配置以及主函数代码。它通过调用 `xrobot_init_mod` 初始化模块，并根据构造参数自动生成主函数代码。
-This tool automates the XRobot setup, generating module repository configuration and main function code. It initializes modules via `xrobot_init_mod`, and automatically generates the main function code based on constructor parameters.
+该工具用于自动配置 XRobot 环境：检查 `Modules/modules.yaml` 与 `Modules/sources.yaml`，拉取模块仓库，并调用 `xrobot_gen_main` 生成 `User/xrobot_main.hpp`。
+This tool automates XRobot workspace setup: it checks `Modules/modules.yaml` and `Modules/sources.yaml`, fetches module repositories, and invokes `xrobot_gen_main` to generate `User/xrobot_main.hpp`.
 
 #### 🚀 使用方法 / Usage
 
@@ -483,8 +525,8 @@ set(XROBOT_MODULES_DIR YOUR_MODULES_PATH) # eg. ${CMAKE_CURRENT_SOURCE_DIR}/Modu
 #### 🎛️ 命令行参数 / Command-Line Arguments
 
 - `--config`, `-c`
-  可选，指定构造参数配置文件路径，可以是本地文件或远程 URL。
-  Optional. Path to constructor configuration file, can be a local file or a URL.
+  当前版本保留该参数位；主流程仍使用 `xrobot_gen_main` 的默认配置路径 `User/xrobot.yaml`。
+  This option is currently reserved; the main flow still uses `xrobot_gen_main` with its default config path `User/xrobot.yaml`.
 
 #### 📤 输出结果 / Output
 
@@ -505,18 +547,26 @@ set(XROBOT_MODULES_DIR YOUR_MODULES_PATH) # eg. ${CMAKE_CURRENT_SOURCE_DIR}/Modu
 ```bash
 Starting XRobot auto-configuration
 
-[INFO] Default config created: ./Modules/modules.yaml
-Please edit the file and rerun.
+[INFO] Created default Modules/modules.yaml
+Please edit this file; each line should be a full module name like:
+  - xrobot-org/BlinkLED
+  - your-namespace/YourModule@dev
+[INFO] Created default Modules/sources.yaml
+Please configure sources index.yaml for official or custom/private mirrors.
+Default official source already included.
 
-[EXEC] xrobot_init_mod --config ./Modules/modules.yaml -d ./Modules
+# edit the generated yaml files, then rerun xrobot_setup
+
+[EXEC] xrobot_init_mod --config Modules/modules.yaml --directory Modules --sources Modules/sources.yaml
 [SUCCESS] All modules and their dependencies processed.
 
-[EXEC] xrobot_gen_main --output ./User/xrobot_main.hpp --config ./User/xrobot.yaml
-[INFO] Constructor config generated: ./User/xrobot.yaml
-Modify the configuration and rerun to apply changes
+[EXEC] xrobot_gen_main --output User/xrobot_main.hpp
+Discovered modules: BlinkLED
+[INFO] Successfully parsed manifest for BlinkLED
+[INFO] Writing configuration to User/xrobot.yaml
+[SUCCESS] Generated entry file: User/xrobot_main.hpp
 
-[EXEC] xrobot_gen_main --output ./User/xrobot_main.hpp --config ./User/xrobot.yaml
-All done! Main function generated at: ./User/xrobot_main.hpp
+All done! Main function generated at: User/xrobot_main.hpp
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xrobot"
-version = "0.2.8"
+version = "0.2.9"
 description = "A lightweight application framework for robot module management, lifecycle control, and hardware abstraction."
 requires-python = ">=3.8"
 authors = [

--- a/src/xrobot/GenerateMain.py
+++ b/src/xrobot/GenerateMain.py
@@ -17,10 +17,12 @@ import yaml
 import argparse
 from pathlib import Path
 from collections import OrderedDict
-from typing import Union, Dict, List
+from typing import Union, Dict, List, Optional
 from yaml.representer import SafeRepresenter
 
 yaml.add_representer(OrderedDict, SafeRepresenter.represent_dict)
+
+CONSTEXPR_NAMESPACE = "XRobotProject"
 
 def parse_manifest_from_header(header_path: Path) -> Dict:
     """
@@ -39,7 +41,7 @@ def parse_manifest_from_header(header_path: Path) -> Dict:
         if "=== END MANIFEST" in stripped:
             break
         if in_manifest:
-            manifest_block.append(line.strip())
+            manifest_block.append(line)
 
     if not manifest_block:
         print(f"[WARN] No manifest found in {header_path}")
@@ -72,12 +74,25 @@ def parse_manifest_from_header(header_path: Path) -> Dict:
     print(f"[INFO] Successfully parsed manifest for {header_path.stem}")
     return manifest_data
 
+def _validate_constexpr_ref(name: str) -> str:
+    if not isinstance(name, str) or not re.match(r"^[A-Za-z_]\w*$", name):
+        raise ValueError(f"[ERROR] Invalid constexpr reference: {name!r}")
+    return name
+
+
+def _is_constexpr_ref(value: object) -> bool:
+    return isinstance(value, dict) and set(value.keys()) == {"constexpr"}
+
+
 def _format_cpp_value(value: Union[dict, list, str, int, float, bool], key: str = "") -> str:
     """
     Format a value as C++-compliant parameter.
-    Supports numbers, bool, identifiers, @instance, string, nested dict as {a,b,c}, and list as {a,b,c}.
+    Supports numbers, bool, identifiers, @instance, {constexpr: Name},
+    string, nested dict as {a,b,c}, and list as {a,b,c}.
     """
     if isinstance(value, dict):
+        if _is_constexpr_ref(value):
+            return f"{CONSTEXPR_NAMESPACE}::{_validate_constexpr_ref(value['constexpr'])}"
         # 输出为聚合初始化列表，顺序由 yaml/OrderedDict 决定
         return '{' + ', '.join(_format_cpp_value(v) for v in value.values()) + '}'
     elif isinstance(value, list):
@@ -99,6 +114,74 @@ def _format_cpp_value(value: Union[dict, list, str, int, float, bool], key: str 
             return f'"{value}"'
     else:
         return str(value)
+
+
+def _format_template_arg(value: Union[dict, list, str, int, float, bool]) -> str:
+    """
+    Format a template argument while preserving raw type-expression strings.
+    """
+    if _is_constexpr_ref(value):
+        return f"{CONSTEXPR_NAMESPACE}::{_validate_constexpr_ref(value['constexpr'])}"
+    if isinstance(value, str):
+        return value
+    return _format_cpp_value(value)
+
+
+def _generate_constexpr_header(config: Dict) -> Optional[str]:
+    constexprs = config.get("constexprs", {})
+    if not constexprs:
+        return None
+    if not isinstance(constexprs, dict):
+        raise TypeError("[ERROR] 'constexprs' must be a mapping")
+
+    include_headers = config.get("constexpr_includes", [])
+    if include_headers is None:
+        include_headers = []
+    if not isinstance(include_headers, list) or not all(isinstance(h, str) for h in include_headers):
+        raise TypeError("[ERROR] 'constexpr_includes' must be a list of header strings")
+
+    lines = ["#pragma once", ""]
+    for header in include_headers:
+        lines.append(f'#include "{header}"')
+    if include_headers:
+        lines.append("")
+    lines.append(f"namespace {CONSTEXPR_NAMESPACE} {{")
+
+    for name, spec in constexprs.items():
+        _validate_constexpr_ref(name)
+        if not isinstance(spec, dict):
+            raise TypeError(f"[ERROR] constexpr '{name}' must be a mapping")
+        cpp_type = spec.get("type")
+        cpp_value = spec.get("value")
+        if not isinstance(cpp_type, str) or not cpp_type:
+            raise ValueError(f"[ERROR] constexpr '{name}' missing non-empty 'type'")
+        if cpp_value is None:
+            raise ValueError(f"[ERROR] constexpr '{name}' missing 'value'")
+        lines.append(f"inline constexpr {cpp_type} {name} = {_format_cpp_value(cpp_value)};")
+
+    lines += [
+        f"}}  // namespace {CONSTEXPR_NAMESPACE}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _load_config_file(config_path: Path) -> Dict:
+    try:
+        config_data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as e:
+        raise ValueError(f"[ERROR] Failed to parse YAML in {config_path}: {e}") from e
+    if not isinstance(config_data, dict):
+        raise TypeError(f"[ERROR] Top-level config in {config_path} must be a mapping")
+    return config_data
+
+
+def _require_mapping(value: object, field_name: str) -> Dict:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError(f"[ERROR] '{field_name}' must be a mapping")
+    return value
 
 def extract_constructor_args(
     modules: List[str], module_dir: Path, config_path: Path
@@ -189,13 +272,19 @@ def generate_xrobot_main_code(hw_var: str, modules: List[str], config: Dict) -> 
     Generate the main application code (C++ entry point) with module instantiations,
     supporting template args and instance id.
     """
-    sleep_ms = config.get("global_settings", {}).get("monitor_sleep_ms", 1000)
+    if not isinstance(config, dict):
+        raise TypeError("[ERROR] top-level config must be a mapping")
+
+    global_settings = _require_mapping(config.get("global_settings", {}), "global_settings")
+    sleep_ms = global_settings.get("monitor_sleep_ms", 1000)
     headers = [
         '#include "app_framework.hpp"',
         '#include "libxr.hpp"',
         "",
         "// Module headers"
     ] + [f'#include "{mod}.hpp"' for mod in modules]
+    if config.get("constexprs"):
+        headers.append('#include "xrobot_constexpr.hpp"')
 
     body = [
         f"static void XRobotMain(LibXR::HardwareContainer &{hw_var}) {{",
@@ -209,14 +298,22 @@ def generate_xrobot_main_code(hw_var: str, modules: List[str], config: Dict) -> 
     if not isinstance(module_entries, list):
         raise TypeError("[ERROR] 'modules' must be a list of module instances")
 
-    # Track auto-assigned instance names per module
     auto_inst_index = {}
 
     for entry in module_entries:
+        if not isinstance(entry, dict):
+            raise TypeError("[ERROR] each item in 'modules' must be a mapping")
+
         mod = entry.get("name")
+        if not isinstance(mod, str) or not mod.strip():
+            raise ValueError("[ERROR] each module entry requires non-empty string 'name'")
+        mod = mod.strip()
+
         inst_id = entry.get("id")
-        if inst_id:
-            instance_name = inst_id
+        if inst_id is not None:
+            if not isinstance(inst_id, str) or not inst_id.strip():
+                raise ValueError(f"[ERROR] module '{mod}' has invalid non-empty string 'id'")
+            instance_name = inst_id.strip()
         else:
             idx = auto_inst_index.get(mod, 0)
             instance_name = f"{mod.lower()}{idx}" if idx > 0 else mod.lower()
@@ -226,15 +323,12 @@ def generate_xrobot_main_code(hw_var: str, modules: List[str], config: Dict) -> 
             print(f"[WARN] Module {mod} not included in the provided list.")
             continue
 
-        args_dict = entry.get("constructor_args", {})
-        if isinstance(args_dict, dict):
-            args_list = [_format_cpp_value(v, k) for k, v in args_dict.items()]
-        else:
-            args_list = []
+        args_dict = _require_mapping(entry.get("constructor_args", {}), f"constructor_args for module '{mod}'")
+        args_list = [_format_cpp_value(v, k) for k, v in args_dict.items()]
 
-        tmpl_dict = entry.get("template_args", {})
-        if isinstance(tmpl_dict, dict) and tmpl_dict:
-            tmpl_params = [str(v) for k, v in tmpl_dict.items()]
+        tmpl_dict = _require_mapping(entry.get("template_args", {}), f"template_args for module '{mod}'")
+        if tmpl_dict:
+            tmpl_params = [_format_template_arg(v) for k, v in tmpl_dict.items()]
             tmpl_str = "<" + ", ".join(tmpl_params) + ">"
         else:
             tmpl_str = ""
@@ -274,23 +368,27 @@ def extract_modules_from_config(config: Dict) -> List[str]:
     Extract a de-duplicated module include list from config["modules"] while
     preserving declaration order.
     """
+    if not isinstance(config, dict):
+        raise TypeError("[ERROR] top-level config must be a mapping")
+
     module_entries = config.get("modules", [])
-    if not isinstance(module_entries, list):
-        print("[WARN] Config field 'modules' is not a list; falling back to discovery.")
+    if module_entries is None:
         return []
+    if not isinstance(module_entries, list):
+        raise TypeError("[ERROR] 'modules' must be a list of module instances")
 
     selected_modules = []
     seen_modules = set()
     for entry in module_entries:
         if not isinstance(entry, dict):
-            continue
+            raise TypeError("[ERROR] each item in 'modules' must be a mapping")
 
         mod = entry.get("name")
-        if not isinstance(mod, str):
-            continue
+        if not isinstance(mod, str) or not mod.strip():
+            raise ValueError("[ERROR] each module entry requires non-empty string 'name'")
 
         mod = mod.strip()
-        if not mod or mod in seen_modules:
+        if mod in seen_modules:
             continue
 
         selected_modules.append(mod)
@@ -310,35 +408,45 @@ def main():
     # Configuration handling
     config_data = {}
     config_path = Path(args.config) if args.config else Path("User/xrobot.yaml")
-    if config_path.exists():
-        print(f"[INFO] Using existing configuration file: {config_path}")
-        config_data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    elif args.config:
-        print(f"[WARN] Configuration file not found: {config_path}")
 
-    # Module selection
-    if not args.modules:
-        args.modules = extract_modules_from_config(config_data)
-        if args.modules:
-            print(f"[INFO] Using modules from configuration: {', '.join(args.modules)}")
-            modules_dir = Path("Modules")
-            for mod in args.modules:
-                hpp = modules_dir / mod / f"{mod}.hpp"
-                if not hpp.exists():
-                    print(f"[WARN] Module '{mod}' declared in config but header not found: {hpp}")
-        else:
-            args.modules = auto_discover_modules()
-            print(f"Discovered modules: {', '.join(args.modules) or 'None'}")
+    try:
+        if config_path.exists():
+            print(f"[INFO] Using existing configuration file: {config_path}")
+            config_data = _load_config_file(config_path)
+        elif args.config:
+            print(f"[WARN] Configuration file not found: {config_path}")
 
-    if not config_path.exists():
-        config_data = extract_constructor_args(args.modules, Path("Modules"), config_path)
+        # Module selection
+        if not args.modules:
+            args.modules = extract_modules_from_config(config_data)
+            if args.modules:
+                print(f"[INFO] Using modules from configuration: {', '.join(args.modules)}")
+                modules_dir = Path("Modules")
+                for mod in args.modules:
+                    hpp = modules_dir / mod / f"{mod}.hpp"
+                    if not hpp.exists():
+                        print(f"[WARN] Module '{mod}' declared in config but header not found: {hpp}")
+            else:
+                args.modules = auto_discover_modules()
+                print(f"Discovered modules: {', '.join(args.modules) or 'None'}")
 
-    # Code generation
-    output_code = generate_xrobot_main_code(args.hw, args.modules, config_data)
-    output_path = Path(args.output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(output_code, encoding="utf-8")
-    print(f"[SUCCESS] Generated entry file: {args.output}")
+        if not config_path.exists():
+            config_data = extract_constructor_args(args.modules, Path("Modules"), config_path)
+
+        # Code generation
+        output_code = generate_xrobot_main_code(args.hw, args.modules, config_data)
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output_code, encoding="utf-8")
+        print(f"[SUCCESS] Generated entry file: {args.output}")
+
+        constexpr_code = _generate_constexpr_header(config_data)
+        if constexpr_code is not None:
+            constexpr_path = output_path.with_name("xrobot_constexpr.hpp")
+            constexpr_path.write_text(constexpr_code, encoding="utf-8")
+            print(f"[SUCCESS] Generated constexpr header: {constexpr_path}")
+    except (TypeError, ValueError, FileNotFoundError) as e:
+        parser.exit(1, f"{e}\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This change adds project-level constexpr generation to `xrobot_gen_main` and tightens the generator's configuration parsing so invalid YAML and malformed config structures fail with clear errors instead of leaking Python tracebacks or silently degrading into incomplete output.

Before this change, project code could only pass literal values or ad-hoc string expressions through `User/xrobot.yaml`. That made it awkward to express strongly typed compile-time configuration shared across modules, especially for template arguments and aggregate constructor arguments. In the same area, the generator's parser had several edge cases that were unsafe in practice: nested manifest YAML could be flattened by indentation loss, top-level non-mapping YAML could reach deep code paths and crash with `AttributeError`, and malformed `global_settings` / `modules` entries could be silently ignored or fail unclearly.

The root cause was that `GenerateMain.py` only handled simple value formatting and assumed a mostly well-formed config tree. It had no project-level constexpr emission path, no dedicated config loader with structural validation, and manifest parsing stripped indentation from lines before handing them to YAML parsing.

The fix adds a project-level `constexprs` / `constexpr_includes` surface to `User/xrobot.yaml`. When present, `xrobot_gen_main` now emits `xrobot_constexpr.hpp`, and both `constructor_args` and `template_args` can reference generated symbols using `{constexpr: Name}`. The generator remains in a single `GenerateMain.py` file, keeps the existing CLI entrypoint, and the package version is bumped to `0.2.9`. README usage was updated to match the real current behavior, including the single-file generator, the `User/xrobot.yaml` layout, and the `xrobot_setup` flow.

This PR also hardens config parsing behavior. Manifest parsing now preserves indentation so nested YAML structures survive round-tripping. Config loading validates that the top-level YAML is a mapping, and generation now validates `global_settings`, each `modules[*]` entry, and per-module `constructor_args` / `template_args` mappings explicitly. On CLI failure paths, these validation errors are surfaced as readable command-line errors instead of raw stack traces.

Validation was done in three layers. First, `python3 -m compileall src/xrobot/GenerateMain.py` was run on the final branch state. Second, an ad-hoc parsing regression and boundary verification matrix was executed with 22 passing checks, covering valid generation, malformed YAML, top-level type errors, malformed module entries, invalid constexpr references, and CLI error surfaces. Third, a local multi-module smoke run exercised real generator flows with mock `BlinkLED`, `WebotsCamera`, `ArmorDetector`, and `PoseFilter` modules, covering manifest-driven default config generation, nested manifest args, config-driven module discovery, `@instance` references, and the new `constexprs` / `constexpr_includes` emission path. Together these checks verify both the new feature and the generator's failure behavior on malformed input.

## Summary by Sourcery

Add project-level constexpr header generation to xrobot_gen_main and harden configuration parsing and CLI error handling.

New Features:
- Introduce project-level constexpr and constexpr_includes configuration in User/xrobot.yaml to generate an xrobot_constexpr.hpp header and support {constexpr: Name} references in constructor and template arguments.

Bug Fixes:
- Tighten YAML and config loading so non-mapping top-level configs, invalid modules lists, or malformed entries raise clear errors instead of silently degrading or crashing with tracebacks.
- Make modules extraction and main generation robust to invalid module declarations by enforcing proper types and required fields and surfacing errors via CLI exit codes.

Enhancements:
- Preserve manifest YAML indentation during parsing to support nested structures.
- Validate overall config structure, global_settings, modules entries, and per-module constructor_args/template_args as mappings with clearer requirements for names and ids.
- Ensure template arguments preserve raw type-expression strings while still supporting constexpr references.
- Improve xrobot_gen_main and xrobot_setup documentation to reflect the single-file generator, updated config layout, and constexpr workflow.
- Update xrobot_setup behavior and README examples to describe the current workspace bootstrap flow and CLI output.

Build:
- Bump package version to 0.2.9 in pyproject.toml to publish the new generator behavior.

Documentation:
- Document the User/xrobot.yaml configuration schema including global_settings, modules, and project-level constexprs, plus updated usage examples for xrobot_gen_main and xrobot_setup.