### PR TITLE
feat: refine project constexpr generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,11 @@ xrobot_gen_main -o main.cpp -m BlinkLED Motor IMU --config User/xrobot.yaml
 global_settings:
   monitor_sleep_ms: 5
 
+constexpr_namespace: ProjectConstexpr
+
 constexpr_includes:
   - libxr_def.hpp
+  - <system_error>
 
 constexprs:
   MainCameraInfo:
@@ -337,8 +340,14 @@ modules:
   `modules` is the module instance list; `id` becomes the generated C++ instance name, and `name` is the module class name.
 - `constructor_args` 与 `template_args` 会按配置顺序展开到构造参数和模板参数中。
   `constructor_args` and `template_args` are expanded into constructor arguments and template arguments in config order.
-- `{constexpr: Name}` 会展开为 `XRobotProject::Name`；若顶层存在 `constexprs`，则会额外生成 `xrobot_constexpr.hpp`。
-  `{constexpr: Name}` expands to `XRobotProject::Name`; when top-level `constexprs` exists, `xrobot_constexpr.hpp` is generated alongside the main file.
+- `constexpr_namespace` 可选，用于指定生成的项目级常量命名空间；默认值为 `ProjectConstexpr`。
+  `constexpr_namespace` is optional and controls the generated project-level constexpr namespace; the default is `ProjectConstexpr`.
+- `{constexpr: Name}` 会展开为 `ProjectConstexpr::Name` 或你配置的 `constexpr_namespace::Name`；若顶层存在 `constexprs`，则会额外生成 `xrobot_constexpr.hpp`。
+  `{constexpr: Name}` expands to `ProjectConstexpr::Name` or your configured `constexpr_namespace::Name`; when top-level `constexprs` exists, `xrobot_constexpr.hpp` is generated alongside the main file.
+- `{expr: Code}` 会原样输出为 C++ 表达式，`{string: Text}` 会强制输出为字符串字面量。
+  `{expr: Code}` is emitted as a raw C++ expression, while `{string: Text}` forces a string literal.
+- `constexpr_includes` 里的条目若写成 `<...>` 或 `"..."` 会按原样输出；裸字符串仍会生成双引号 include。
+  Entries in `constexpr_includes` preserve raw `<...>` / `"..."` forms; bare strings still emit quoted includes.
 - `@instance_id` 会被当作已有 C++ 实例名直接引用，例如 `@cam` 会展开为 `cam`。
   `@instance_id` is emitted as a direct C++ instance reference, for example `@cam` expands to `cam`.
 
@@ -346,8 +355,8 @@ modules:
 
 - 生成一个包含 `XRobotMain()` 的 `.hpp` 或 `.cpp` 文件。
   Generates a `.hpp` or `.cpp` file containing `XRobotMain()`.
-- 当配置里存在 `constexprs` 时，会在输出文件同目录额外生成 `xrobot_constexpr.hpp`。
-  When `constexprs` exists in the config, an extra `xrobot_constexpr.hpp` file is generated next to the main output.
+- 当配置里存在 `constexprs` 时，会在输出文件同目录额外生成 `xrobot_constexpr.hpp`；主文件会先 include 模块头，再 include 该头文件。
+  When `constexprs` exists in the config, an extra `xrobot_constexpr.hpp` file is generated next to the main output; the main file includes module headers first and then includes that header.
 - 每个模块按 `static ModuleName<...> id(hw, appmgr, ...);` 形式实例化。
   Each module instance is emitted in the form `static ModuleName<...> id(hw, appmgr, ...);`.
 - 主循环使用 `appmgr.MonitorAll()` 与 `Thread::Sleep(monitor_sleep_ms)`。
@@ -369,8 +378,11 @@ static void XRobotMain(LibXR::HardwareContainer &hw) {
   ApplicationManager appmgr;
 
   // Auto-generated module instantiations
-  static WebotsCamera<XRobotProject::MainCameraInfo> cam(hw, appmgr, XRobotProject::MainCameraInfo);
-  static ArmorDetector detector(hw, appmgr, cam, XRobotProject::DebugEnable);
+  static WebotsCamera<ProjectConstexpr::MainCameraInfo> cam(
+      hw,
+      appmgr,
+      ProjectConstexpr::MainCameraInfo);
+  static ArmorDetector detector(hw, appmgr, cam, ProjectConstexpr::DebugEnable);
 
   while (true) {
     appmgr.MonitorAll();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xrobot"
-version = "0.2.9"
+version = "0.2.10"
 description = "A lightweight application framework for robot module management, lifecycle control, and hardware abstraction."
 requires-python = ">=3.8"
 authors = [

--- a/src/xrobot/GenerateMain.py
+++ b/src/xrobot/GenerateMain.py
@@ -196,6 +196,7 @@ def extract_constructor_args(
         },
         "modules": []
     }
+    auto_inst_index = {}
 
     for mod in modules:
         hpp_path = module_dir / mod / f"{mod}.hpp"
@@ -249,7 +250,11 @@ def extract_constructor_args(
                 tmpl_ordered.update(d)
 
         # Generate config entry for module
+        idx = auto_inst_index.get(mod, 0)
+        instance_id = f"{mod}_{idx}"
+        auto_inst_index[mod] = idx + 1
         mod_entry = OrderedDict([
+            ("id", instance_id),
             ("name", mod),
             ("constructor_args", args_ordered)
         ])

--- a/src/xrobot/GenerateMain.py
+++ b/src/xrobot/GenerateMain.py
@@ -13,6 +13,7 @@ Usage example:
 """
 
 import re
+import json
 import yaml
 import argparse
 from pathlib import Path
@@ -22,7 +23,7 @@ from yaml.representer import SafeRepresenter
 
 yaml.add_representer(OrderedDict, SafeRepresenter.represent_dict)
 
-CONSTEXPR_NAMESPACE = "XRobotProject"
+DEFAULT_CONSTEXPR_NAMESPACE = "ProjectConstexpr"
 
 def parse_manifest_from_header(header_path: Path) -> Dict:
     """
@@ -74,57 +75,164 @@ def parse_manifest_from_header(header_path: Path) -> Dict:
     print(f"[INFO] Successfully parsed manifest for {header_path.stem}")
     return manifest_data
 
-def _validate_constexpr_ref(name: str) -> str:
+def _validate_cpp_identifier(name: str, field_name: str = "identifier") -> str:
     if not isinstance(name, str) or not re.match(r"^[A-Za-z_]\w*$", name):
-        raise ValueError(f"[ERROR] Invalid constexpr reference: {name!r}")
+        raise ValueError(f"[ERROR] Invalid {field_name}: {name!r}")
     return name
 
 
+def _validate_constexpr_ref(name: str) -> str:
+    return _validate_cpp_identifier(name, "constexpr reference")
+
+
+def _get_constexpr_namespace(config: Dict) -> str:
+    return _validate_cpp_identifier(
+        config.get("constexpr_namespace", DEFAULT_CONSTEXPR_NAMESPACE),
+        "constexpr namespace",
+    )
+
+
+def _is_single_key_mapping(value: object, key: str) -> bool:
+    return isinstance(value, dict) and set(value.keys()) == {key}
+
+
 def _is_constexpr_ref(value: object) -> bool:
-    return isinstance(value, dict) and set(value.keys()) == {"constexpr"}
+    return _is_single_key_mapping(value, "constexpr")
 
 
-def _format_cpp_value(value: Union[dict, list, str, int, float, bool], key: str = "") -> str:
+def _is_expr_value(value: object) -> bool:
+    return _is_single_key_mapping(value, "expr")
+
+
+def _is_string_value(value: object) -> bool:
+    return _is_single_key_mapping(value, "string")
+
+
+def _format_include_directive(header: str) -> str:
+    header = header.strip()
+    if not header:
+        raise ValueError("[ERROR] include header must be a non-empty string")
+    if (header.startswith("<") and header.endswith(">")) or (
+        header.startswith('"') and header.endswith('"')
+    ):
+        return f"#include {header}"
+    return f'#include "{header}"'
+
+
+def _format_raw_expr(value: object) -> str:
+    if isinstance(value, (dict, list)) or value is None:
+        raise TypeError("[ERROR] 'expr' must be a scalar value")
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    expr = str(value).strip()
+    if not expr:
+        raise ValueError("[ERROR] 'expr' must be a non-empty scalar")
+    return expr
+
+
+def _format_string_literal(value: object) -> str:
+    if isinstance(value, (dict, list)) or value is None:
+        raise TypeError("[ERROR] 'string' must be a scalar value")
+    if isinstance(value, bool):
+        return json.dumps("true" if value else "false")
+    return json.dumps(str(value))
+
+
+def _format_cpp_value(
+    value: Union[dict, list, str, int, float, bool],
+    key: str = "",
+    constexpr_namespace: str = DEFAULT_CONSTEXPR_NAMESPACE,
+) -> str:
     """
     Format a value as C++-compliant parameter.
     Supports numbers, bool, identifiers, @instance, {constexpr: Name},
-    string, nested dict as {a,b,c}, and list as {a,b,c}.
+    {expr: RawExpr}, {string: Literal}, nested dict as {a,b,c}, and list as {a,b,c}.
     """
     if isinstance(value, dict):
         if _is_constexpr_ref(value):
-            return f"{CONSTEXPR_NAMESPACE}::{_validate_constexpr_ref(value['constexpr'])}"
-        # 输出为聚合初始化列表，顺序由 yaml/OrderedDict 决定
-        return '{' + ', '.join(_format_cpp_value(v) for v in value.values()) + '}'
-    elif isinstance(value, list):
-        return '{' + ', '.join(_format_cpp_value(v) for v in value) + '}'
-    elif isinstance(value, bool):
+            return f"{constexpr_namespace}::{_validate_constexpr_ref(value['constexpr'])}"
+        if _is_expr_value(value):
+            return _format_raw_expr(value["expr"])
+        if _is_string_value(value):
+            return _format_string_literal(value["string"])
+        return '{' + ', '.join(
+            _format_cpp_value(v, constexpr_namespace=constexpr_namespace)
+            for v in value.values()
+        ) + '}'
+    if isinstance(value, list):
+        return '{' + ', '.join(
+            _format_cpp_value(v, constexpr_namespace=constexpr_namespace)
+            for v in value
+        ) + '}'
+    if isinstance(value, bool):
         return "true" if value else "false"
-    elif isinstance(value, str):
-        # @instance 变量
+    if isinstance(value, str):
         if value.startswith('@'):
             return value[1:]
-        # C++ 枚举、作用域名等
         if re.match(r"^[A-Za-z_][\w:<>\s,]*::[A-Za-z_][\w:]*$", value):
             return value
-        # 纯数字
-        elif re.match(r"^-?\d+(\.\d+)?$", value):
+        if re.match(r"^-?\d+(\.\d+)?$", value):
             return value
-        # 普通字符串
-        else:
-            return f'"{value}"'
-    else:
-        return str(value)
+        return _format_string_literal(value)
+    return str(value)
 
 
-def _format_template_arg(value: Union[dict, list, str, int, float, bool]) -> str:
+def _format_template_arg(
+    value: Union[dict, list, str, int, float, bool],
+    constexpr_namespace: str = DEFAULT_CONSTEXPR_NAMESPACE,
+) -> str:
     """
     Format a template argument while preserving raw type-expression strings.
     """
     if _is_constexpr_ref(value):
-        return f"{CONSTEXPR_NAMESPACE}::{_validate_constexpr_ref(value['constexpr'])}"
+        return f"{constexpr_namespace}::{_validate_constexpr_ref(value['constexpr'])}"
+    if _is_expr_value(value):
+        return _format_raw_expr(value["expr"])
+    if _is_string_value(value):
+        return _format_string_literal(value["string"])
     if isinstance(value, str):
         return value
-    return _format_cpp_value(value)
+    return _format_cpp_value(value, constexpr_namespace=constexpr_namespace)
+
+
+def _format_multiline_template_type(mod: str, tmpl_params: List[str]) -> List[str]:
+    lines = [f"{mod}<"]
+    for idx, param in enumerate(tmpl_params):
+        comma = "," if idx < len(tmpl_params) - 1 else ""
+        lines.append(f"      {param}{comma}")
+    lines.append("  >")
+    return lines
+
+
+def _format_module_instance_statement(
+    mod: str,
+    tmpl_params: List[str],
+    instance_name: str,
+    hw_var: str,
+    args_list: List[str],
+) -> str:
+    call_args = [hw_var, "appmgr", *args_list]
+    type_expr = mod
+    if tmpl_params:
+        type_expr += "<" + ", ".join(tmpl_params) + ">"
+
+    single_line = f"  static {type_expr} {instance_name}(" + ", ".join(call_args) + ");"
+    if len(single_line) <= 100:
+        return single_line
+
+    if tmpl_params and len(type_expr) > 48:
+        type_lines = _format_multiline_template_type(mod, tmpl_params)
+        lines = [f"  static {type_lines[0]}"]
+        lines.extend(type_lines[1:-1])
+        lines.append(f"{type_lines[-1]} {instance_name}(")
+    else:
+        lines = [f"  static {type_expr} {instance_name}("]
+
+    for idx, arg in enumerate(call_args):
+        comma = "," if idx < len(call_args) - 1 else ""
+        lines.append(f"      {arg}{comma}")
+    lines.append("  );")
+    return "\n".join(lines)
 
 
 def _generate_constexpr_header(config: Dict) -> Optional[str]:
@@ -140,12 +248,21 @@ def _generate_constexpr_header(config: Dict) -> Optional[str]:
     if not isinstance(include_headers, list) or not all(isinstance(h, str) for h in include_headers):
         raise TypeError("[ERROR] 'constexpr_includes' must be a list of header strings")
 
+    constexpr_namespace = _get_constexpr_namespace(config)
+
     lines = ["#pragma once", ""]
+    emitted_includes = []
+    seen_includes = set()
     for header in include_headers:
-        lines.append(f'#include "{header}"')
-    if include_headers:
+        directive = _format_include_directive(header)
+        if directive in seen_includes:
+            continue
+        seen_includes.add(directive)
+        emitted_includes.append(directive)
+    lines.extend(emitted_includes)
+    if emitted_includes:
         lines.append("")
-    lines.append(f"namespace {CONSTEXPR_NAMESPACE} {{")
+    lines.append(f"namespace {constexpr_namespace} {{")
 
     for name, spec in constexprs.items():
         _validate_constexpr_ref(name)
@@ -157,10 +274,13 @@ def _generate_constexpr_header(config: Dict) -> Optional[str]:
             raise ValueError(f"[ERROR] constexpr '{name}' missing non-empty 'type'")
         if cpp_value is None:
             raise ValueError(f"[ERROR] constexpr '{name}' missing 'value'")
-        lines.append(f"inline constexpr {cpp_type} {name} = {_format_cpp_value(cpp_value)};")
+        lines.append(
+            f"inline constexpr {cpp_type} {name} = "
+            f"{_format_cpp_value(cpp_value, constexpr_namespace=constexpr_namespace)};"
+        )
 
     lines += [
-        f"}}  // namespace {CONSTEXPR_NAMESPACE}",
+        f"}}  // namespace {constexpr_namespace}",
         "",
     ]
     return "\n".join(lines)
@@ -282,21 +402,23 @@ def generate_xrobot_main_code(hw_var: str, modules: List[str], config: Dict) -> 
 
     global_settings = _require_mapping(config.get("global_settings", {}), "global_settings")
     sleep_ms = global_settings.get("monitor_sleep_ms", 1000)
+    constexpr_namespace = _get_constexpr_namespace(config)
+
     headers = [
         '#include "app_framework.hpp"',
         '#include "libxr.hpp"',
         "",
-        "// Module headers"
+        "// Module headers",
     ] + [f'#include "{mod}.hpp"' for mod in modules]
     if config.get("constexprs"):
         headers.append('#include "xrobot_constexpr.hpp"')
 
     body = [
         f"static void XRobotMain(LibXR::HardwareContainer &{hw_var}) {{",
-        f"  using namespace LibXR;",
-        f"  ApplicationManager appmgr;",
-        f"",
-        f"  // Auto-generated module instantiations",
+        "  using namespace LibXR;",
+        "  ApplicationManager appmgr;",
+        "",
+        "  // Auto-generated module instantiations",
     ]
 
     module_entries = config.get("modules", [])
@@ -328,29 +450,32 @@ def generate_xrobot_main_code(hw_var: str, modules: List[str], config: Dict) -> 
             print(f"[WARN] Module {mod} not included in the provided list.")
             continue
 
-        args_dict = _require_mapping(entry.get("constructor_args", {}), f"constructor_args for module '{mod}'")
-        args_list = [_format_cpp_value(v, k) for k, v in args_dict.items()]
+        args_dict = _require_mapping(
+            entry.get("constructor_args", {}),
+            f"constructor_args for module '{mod}'",
+        )
+        args_list = [
+            _format_cpp_value(v, k, constexpr_namespace=constexpr_namespace)
+            for k, v in args_dict.items()
+        ]
 
         tmpl_dict = _require_mapping(entry.get("template_args", {}), f"template_args for module '{mod}'")
-        if tmpl_dict:
-            tmpl_params = [_format_template_arg(v) for k, v in tmpl_dict.items()]
-            tmpl_str = "<" + ", ".join(tmpl_params) + ">"
-        else:
-            tmpl_str = ""
+        tmpl_params = [
+            _format_template_arg(v, constexpr_namespace=constexpr_namespace)
+            for _, v in tmpl_dict.items()
+        ]
 
-        instance_line = f"  static {mod}{tmpl_str} {instance_name}({hw_var}, appmgr"
-        if args_list:
-            instance_line += ", " + ", ".join(args_list)
-        instance_line += ");"
-        body.append(instance_line)
+        body.append(
+            _format_module_instance_statement(mod, tmpl_params, instance_name, hw_var, args_list)
+        )
 
     body += [
         "",
-        f"  while (true) {{",
-        f"    appmgr.MonitorAll();",
+        "  while (true) {",
+        "    appmgr.MonitorAll();",
         f"    Thread::Sleep({sleep_ms});",
-        f"  }}",
-        f"}}"
+        "  }",
+        "}",
     ]
 
     return "\n".join(headers + [""] + body)


### PR DESCRIPTION
This PR refines the recently added project-level constexpr generation path and folds in one missing config-generation fix that is still absent from `XRobot2.0`.

The first problem is that auto-generated `User/xrobot.yaml` entries still omit stable instance ids. That breaks module-to-module references on the autogen path because downstream configs and examples expect names like `BlinkLED_0`, but the generated config only kept `name`. This PR preserves auto-generated ids in the generated config so the generated C++ instance names and config references stay aligned.

The second problem is that the current project-level constexpr path is still too rigid and slightly misleading for real use. The namespace is hard-coded, include rendering forces quoted includes, string-vs-expression intent still relies on inference, and long generated instantiations become hard to read. In addition, the generated `xrobot_constexpr.hpp` does not need to auto-inject module headers when it is already consumed as part of the generated entry chain.

This PR makes the constexpr generation path more explicit and easier to use:

- keeps `ProjectConstexpr` as the default namespace but adds top-level `constexpr_namespace` override support
- adds explicit `{expr: ...}` and `{string: ...}` forms so YAML can describe intent without relying only on parser heuristics
- preserves raw `<...>` and `"..."` forms in `constexpr_includes`
- keeps module headers in `xrobot_main.hpp` and limits `xrobot_constexpr.hpp` to explicit includes only
- wraps long generated module instantiations across multiple lines for readability
- bumps the package version from `0.2.9` to `0.2.10`

I also updated the README so the documented config syntax matches the current generator behavior and examples.

Validation used for this branch:

- local `python3 -m compileall src/xrobot/GenerateMain.py`
- local regeneration of default and constexpr sample outputs under `/tmp/xrobot_constexpr_selfcontained_local_20260419`
- Ubuntu24 real compile for the regular constexpr sample:
  - `/home/xiao/runs/xrobot_cfg_refine_20260419T2358Z`
- Ubuntu24 real compile for a probe config covering custom `constexpr_namespace` plus `{expr}` / `{string}`:
  - `/home/xiao/runs/xrobot_cfg_probe_20260420T0002Z`

## Summary by Sourcery

Refine project-level constexpr code generation and auto-generated module configs to make generated C++ instances, namespaces, and includes more flexible and aligned with configuration intent.

New Features:
- Allow overriding the project constexpr namespace via a top-level constexpr_namespace setting in the config.
- Support explicit {expr: ...} and {string: ...} markers in YAML configs to control whether values are emitted as raw C++ expressions or string literals.

Bug Fixes:
- Preserve stable auto-generated module instance ids in generated User/xrobot.yaml so C++ instance names and config references remain consistent.

Enhancements:
- Improve constexpr include handling to honor raw <...>/<...> or "..." forms, deduplicate includes, and keep module headers only in the main header.
- Route all constexpr and template references through the configurable namespace and validate identifiers more robustly.
- Reformat long generated module instantiation statements across multiple lines for better readability.

Build:
- Bump the Python package version from 0.2.9 to 0.2.10.

Documentation:
- Update README examples and explanations to document constexpr_namespace, {expr}/{string} usage, updated constexpr behavior, and the new include ordering.