### PR TITLE
[codex] fix Python 3.8/3.9 import compatibility

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -125,6 +125,24 @@ jobs:
           name: python-package-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}
           path: dist/*
 
+      - name: Install built package (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          pip install dist/*.whl || pip install dist/*.tar.gz
+
+      - name: Install built package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $pkg = Get-ChildItem dist\*.whl,dist\*.tar.gz | Select-Object -First 1
+          if ($pkg) {
+            pip install $pkg.FullName
+          }
+
+      - name: Import smoke check (all top-level modules)
+        run: |
+          python ./scripts/ci_import_smoke.py
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xrobot"
-version = "0.2.10"
+version = "0.3.0"
 description = "A lightweight application framework for robot module management, lifecycle control, and hardware abstraction."
 requires-python = ">=3.8"
 authors = [

--- a/scripts/ci_import_smoke.py
+++ b/scripts/ci_import_smoke.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Import all top-level xrobot modules from the installed package."""
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src" / "xrobot"
+
+    failures = []
+    imported = []
+
+    for path in sorted(src_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+
+        module_name = f"xrobot.{path.stem}"
+        try:
+            importlib.import_module(module_name)
+            imported.append(module_name)
+        except Exception as error:
+            failures.append((module_name, error))
+
+    print(f"Imported {len(imported)} modules.")
+    for module_name in imported:
+        print(f"OK  {module_name}")
+
+    if failures:
+        print(f"Failed to import {len(failures)} modules.", file=sys.stderr)
+        for module_name, error in failures:
+            print(f"ERR {module_name}: {error}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/xrobot/SourceManager.py
+++ b/src/xrobot/SourceManager.py
@@ -10,6 +10,7 @@ import argparse
 import sys
 import logging
 from pathlib import Path
+from typing import Optional, Union
 import yaml
 import requests
 
@@ -25,7 +26,7 @@ def extract_name_from_url(url: str) -> str:
         name = name[:-4]
     return name
 
-def load_yaml(source: str | Path) -> dict:
+def load_yaml(source: Union[str, Path]) -> dict:
     """
     Load YAML from a local file or http(s) URL.
     Returns a dict (empty if content is empty or not a dict).
@@ -46,7 +47,7 @@ def load_yaml(source: str | Path) -> dict:
         logging.warning(f"[WARN] Failed to load yaml: {source} ({e})")
         return {}
 
-def save_yaml(path: str | Path, data: dict):
+def save_yaml(path: Union[str, Path], data: dict):
     """
     Save YAML data to a local file.
     """
@@ -136,7 +137,7 @@ class SourceManager:
         if Path(sources_yaml).exists():
             self.load_sources(sources_yaml)
 
-    def load_sources(self, yaml_path: Path | str):
+    def load_sources(self, yaml_path: Union[Path, str]):
         """
         Load all sources from sources.yaml and merge their modules.
         """
@@ -174,7 +175,7 @@ class SourceManager:
         """
         return sorted(self.module_map.keys())
 
-    def get_repo_url(self, modid: str) -> str | None:
+    def get_repo_url(self, modid: str) -> Optional[str]:
         """
         Return the repository URL for the given module.
         """

--- a/src/xrobot/XRobotSetup.py
+++ b/src/xrobot/XRobotSetup.py
@@ -65,7 +65,7 @@ def ensure_modules_and_sources():
     if created:
         sys.exit(0)  # Exit after template creation, waiting for user edit
 
-def run_subprocess(cmd: list[str]):
+def run_subprocess(cmd: List[str]):
     """
     Execute an external command, log and catch errors.
     """


### PR DESCRIPTION
Fixes #97.

This change fixes the Python-version compatibility regression reported in issue #97.

The immediate user-facing failure was that `xrobot_setup` crashed during import on Python 3.9 because `xrobot.SourceManager` used PEP 604 union type syntax such as `str | Path`, which is only valid at runtime on Python 3.10 and newer. The package metadata, however, still declares `Requires-Python >=3.8`, so the installed package could be pulled into Python 3.8 and 3.9 environments even though some modules were no longer importable there.

The fix keeps the declared Python support floor and makes the affected modules compatible with that floor again. In `SourceManager.py`, the PEP 604 annotations are replaced with `typing.Union` and `typing.Optional`. In `XRobotSetup.py`, the `list[str]` annotation is replaced with `typing.List[str]`, which is also required for real Python 3.8 compatibility. Together these changes remove the import-time incompatibilities while preserving behavior.

This PR also adds a small CI guard so the same class of regression is caught automatically next time. After the wheel or sdist is built in the existing Python version matrix job, the workflow now installs the built package and runs `scripts/ci_import_smoke.py`, which imports every top-level `xrobot` module from the installed package. That turns this issue from a user-reported runtime surprise into a direct CI failure on unsupported syntax regressions.

Validation for this change was done locally in two ways. First, the repository was rescanned to make sure no remaining top-level type annotations relied on PEP 604 or PEP 585 generics in the affected modules. Second, the package was built and installed into a clean virtual environment and `python scripts/ci_import_smoke.py` completed successfully, importing all top-level modules, including `xrobot.SourceManager` and `xrobot.XRobotSetup`.

## Summary by Sourcery

Restore Python 3.8–3.9 compatibility and add a CI smoke test to catch import-time regressions for xrobot modules.

Bug Fixes:
- Replace Python 3.10-only PEP 604 and PEP 585-style type annotations with typing.Union, typing.Optional, and typing.List equivalents to make xrobot modules importable on Python 3.8 and 3.9.

Enhancements:
- Add an import smoke test script that imports all top-level xrobot modules from the installed package.
- Bump the project version to 0.3.0 to reflect the compatibility and CI changes.

CI:
- Extend the Python publish workflow to install the built distribution on all platforms and run the import smoke test as part of the matrix build.
